### PR TITLE
Generate critical css

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -1,0 +1,41 @@
+<?php
+namespace UCF\Critical_CSS\Admin {
+	/**
+	 * Utility functions for registering actions dynamically
+	 */
+	class Actions {
+		/**
+		 * Creates the save_post actions for the
+		 * enabled post types.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @return void
+		 */
+		public static function save_post_actions() {
+			$enabled_post_types = get_field( 'allowed_post_types', 'option' );
+
+			if ( ! $enabled_post_types ) return;
+
+			foreach( $enabled_post_types as $post_type ) {
+				add_action( "save_post_$post_type", array( __NAMESPACE__ . "\Utilities", 'on_save_post' ), 10, 2 );
+			}
+		}
+
+		/**
+		 * Creates the edit_term actions for the
+		 * enabled taxonomies
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @return void
+		 */
+		 public static function edit_term_actions() {
+			$enabled_taxonomies = get_field( 'allowed_taxonomies', 'option' );
+
+			if ( ! $enabled_taxonomies ) return;
+
+			foreach( $enabled_taxonomies as $tax ) {
+				add_action( "edit_$tax", array( __NAMESPACE__ . '\Utilities', 'on_edit_term' ), 10, 2 );
+			}
+		}
+	}
+}

--- a/admin/actions.php
+++ b/admin/actions.php
@@ -34,7 +34,8 @@ namespace UCF\Critical_CSS\Admin {
 			if ( ! $enabled_taxonomies ) return;
 
 			foreach( $enabled_taxonomies as $tax ) {
-				add_action( "edit_$tax", array( __NAMESPACE__ . '\Utilities', 'on_edit_term' ), 10, 2 );
+				add_action( "create_$tax", array( __NAMESPACE__ . '\Utilities', 'on_edit_taxonomy' ), 10, 2 );
+				add_action( "edit_$tax", array( __NAMESPACE__ . '\Utilities', 'on_edit_taxonomy' ), 10, 2 );
 			}
 		}
 	}

--- a/admin/actions.php
+++ b/admin/actions.php
@@ -13,8 +13,9 @@ namespace UCF\Critical_CSS\Admin {
 		 */
 		public static function save_post_actions() {
 			$enabled_post_types = get_field( 'allowed_post_types', 'option' );
+			$generate = get_field( 'enable_critical_css_generation', 'option' );
 
-			if ( ! $enabled_post_types ) return;
+			if ( ! $enabled_post_types || $generate === false ) return;
 
 			foreach( $enabled_post_types as $post_type ) {
 				add_action( "save_post_$post_type", array( __NAMESPACE__ . "\Utilities", 'on_save_post' ), 10, 2 );
@@ -30,8 +31,9 @@ namespace UCF\Critical_CSS\Admin {
 		 */
 		 public static function edit_term_actions() {
 			$enabled_taxonomies = get_field( 'allowed_taxonomies', 'option' );
+			$generate = get_field( 'enable_critical_css_generation', 'option' );
 
-			if ( ! $enabled_taxonomies ) return;
+			if ( ! $enabled_taxonomies || $generate === false ) return;
 
 			foreach( $enabled_taxonomies as $tax ) {
 				add_action( "create_$tax", array( __NAMESPACE__ . '\Utilities', 'on_edit_taxonomy' ), 10, 2 );

--- a/admin/config.php
+++ b/admin/config.php
@@ -125,6 +125,14 @@ namespace UCF\Critical_CSS\Admin {
 			);
 
 			$fields[] = array(
+				'key'           => 'ucfccss_critical_css_service_key',
+				'label'         => 'Critical CSS Service API Key',
+				'name'          => 'critical_css_service_key',
+				'type'          => 'password',
+				'instructions'  => 'Enter the Service API Key for the API Endpoint'
+			);
+
+			$fields[] = array(
 				'key'           => 'ucfccss_excluded_css_selectors',
 				'label'         => 'Excluded CSS Selectors',
 				'name'          => 'excluded_css_selectors',

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -13,11 +13,26 @@ namespace UCF\Critical_CSS\Admin {
 		 * @param WP_Post $post The post object
 		 */
 		public static function on_save_post( $post_id, $post ) {
-			self::request_object_critical_css( $post );
+			$generate = get_field( 'enable_critical_css_generation', 'option' );
+
+			if ( $generate ) {
+				self::request_object_critical_css( $post );
+			}
 		}
 
-		public static function on_edit_term( $term_id, $term ) {
-			self::request_object_critical_css( $term, true );
+		/**
+		 * Function to use for the edit_taxonomy hook.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param int $post_id The ID of the post.
+		 * @param WP_Post $post The post object
+		 */
+		public static function on_edit_taxonomy( $term_id, $term ) {
+			$generate = get_field( 'enable_critical_css_generation', 'option' );
+
+			if ( $generate ) {
+				self::request_object_critical_css( $term, true );
+			}
 		}
 
 		/**
@@ -51,7 +66,7 @@ namespace UCF\Critical_CSS\Admin {
 			$meta = array(
 				'response_url' => '', // The url of the API. Leaving blank for now.
 				'job_type'     => 'object', // We'll look for specific things for this job type
-				'object_type'  => $is_term ? 'term', 'post',
+				'object_type'  => $is_term ? 'term' : 'post',
 				'object_id'    => $is_term ? $object->term_id : $object->ID
 			);
 
@@ -93,7 +108,7 @@ namespace UCF\Critical_CSS\Admin {
 
 			$retval['args'] = array(
 				'dimensions' => $dimensions_formatted,
-				'html'       => $html
+				'html'       => $html,
 				'meta'       => $meta
 			);
 

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -70,7 +70,15 @@ namespace UCF\Critical_CSS\Admin {
 				'object_id'    => $is_term ? $object->term_id : $object->ID
 			);
 
-			$request_body = self::build_critical_css_request( $html, $meta );
+			/**
+			 * If the HTML is more than 64kb, set it to null. The URL will be
+			 * used instead for the critical process.
+			 */
+			if ( strlen( $html ) >= UCF_CRITICAL_CSS__MAX_MSG_SIZE ) {
+				$html = null;
+			}
+
+			$request_body = self::build_critical_css_request( $html, $url, $meta );
 			$request_url = get_field( 'critical_css_service_url', 'option' );
 
 			$response = wp_remote_post( $request_url, array(
@@ -89,7 +97,7 @@ namespace UCF\Critical_CSS\Admin {
 		 * @param string $html The HTML to be processed
 		 * @return string
 		 */
-		private static function build_critical_css_request( $html, $meta ) {
+		private static function build_critical_css_request( $html, $url, $meta ) {
 			$retval = array();
 
 			$exclude = get_field( 'excluded_css_selectors', 'option' );
@@ -109,7 +117,8 @@ namespace UCF\Critical_CSS\Admin {
 			$retval['args'] = array(
 				'dimensions' => $dimensions_formatted,
 				'html'       => $html,
-				'meta'       => $meta
+				'meta'       => $meta,
+				'url'        => $url
 			);
 
 			if ( $exclude ) {

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -13,11 +13,7 @@ namespace UCF\Critical_CSS\Admin {
 		 * @param WP_Post $post The post object
 		 */
 		public static function on_save_post( $post_id, $post ) {
-			$generate = get_field( 'enable_critical_css_generation', 'option' );
-
-			if ( $generate ) {
-				self::request_object_critical_css( $post );
-			}
+			self::request_object_critical_css( $post );
 		}
 
 		/**
@@ -28,11 +24,7 @@ namespace UCF\Critical_CSS\Admin {
 		 * @param WP_Post $post The post object
 		 */
 		public static function on_edit_taxonomy( $term_id, $term ) {
-			$generate = get_field( 'enable_critical_css_generation', 'option' );
-
-			if ( $generate ) {
-				self::request_object_critical_css( $term, true );
-			}
+			self::request_object_critical_css( $term, true );
 		}
 
 		/**

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Utilities for sending the requests to generate critical CSS
+ */
+namespace UCF\Critical_CSS\Admin {
+	class Utilities {
+
+		/**
+		 * Function to use for the save_post hook.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param int $post_id The ID of the post.
+		 * @param WP_Post $post The post object
+		 */
+		public static function on_save_post( $post_id, $post ) {
+			self::request_object_critical_css( $post );
+		}
+
+		public static function on_edit_term( $term_id, $term ) {
+			self::request_object_critical_css( $term, true );
+		}
+
+		/**
+		 * Requests critical CSS to be generated for a
+		 * post or term.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param WP_Post|WP_Term $object_id The post or term id of the object
+		 */
+		public static function request_object_critical_css( $object, $is_term = false ) {
+			// Let's get the HTML
+			$args = array(
+				'timeout' => 15,
+				'cookies' => array()
+			);
+
+			$url = $is_term ?
+				get_term_link( $object ) :
+				get_permalink( $object );
+
+			// We couldn't find a permalink, so return out.
+			if ( ! $url ) return;
+
+			$response = wp_remote_get( $url, $args );
+
+			// We couldn't get the page for whatever reason, return out.
+			if ( is_wp_error( $response ) ) return;
+
+			$html = wp_remote_retrieve_body( $response );
+
+			$meta = array(
+				'response_url' => '', // The url of the API. Leaving blank for now.
+				'job_type'     => 'object', // We'll look for specific things for this job type
+				'object_type'  => $is_term ? 'term', 'post',
+				'object_id'    => $is_term ? $object->term_id : $object->ID
+			);
+
+			$request_body = self::build_critical_css_request( $html, $meta );
+			$request_url = get_field( 'critical_css_service_url', 'option' );
+
+			$response = wp_remote_post( $request_url, array(
+				'body' => $request_body
+			) );
+
+			if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
+				error_log( 'Failed to enqueue critical css request' );
+			}
+		}
+
+		/**
+		 * Builds the critical css request object
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param string $html The HTML to be processed
+		 * @return string
+		 */
+		private static function build_critical_css_request( $html, $meta ) {
+			$retval = array();
+
+			$exclude = get_field( 'excluded_css_selectors', 'option' );
+			$dimensions = get_field( 'critical_css_dimensions', 'option' );
+
+			$exclude = ! empty( $exclude ) ? explode( "\n", $exclude ) : null;
+
+			$dimensions_formatted = array();
+
+			foreach( $dimensions as $dimension ) {
+				$dimensions_formatted[] = array(
+					'width'  => $dimension['width'],
+					'height' => $dimension['height']
+				);
+			}
+
+			$retval['args'] = array(
+				'dimensions' => $dimensions_formatted,
+				'html'       => $html
+				'meta'       => $meta
+			);
+
+			if ( $exclude ) {
+				$retval['args']['exclude'] = $exclude;
+			}
+
+			$retval = json_encode( $retval );
+
+			return $retval;
+		}
+	}
+}

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -56,8 +56,7 @@ namespace UCF\Critical_CSS\Admin {
 			$html = wp_remote_retrieve_body( $response );
 
 			$meta = array(
-				'response_url' => '', // The url of the API. Leaving blank for now.
-				'job_type'     => 'object', // We'll look for specific things for this job type
+				'response_url' => get_rest_url( null, 'ucfccss/v1/update/single/' ), // The url of the API. Leaving blank for now.
 				'object_type'  => $is_term ? 'term' : 'post',
 				'object_id'    => $is_term ? $object->term_id : $object->ID
 			);

--- a/api/api.php
+++ b/api/api.php
@@ -108,6 +108,9 @@ namespace UCF\Critical_CSS\API {
 				);
 			}
 
+			// Delete the transient
+			delete_transient( $csrf );
+
 			if ( $success === false ) {
 				$retval['result'] = 'error';
 				$retval['message'] = "There was an error updating the $object_type meta";

--- a/api/api.php
+++ b/api/api.php
@@ -1,0 +1,121 @@
+<?php
+namespace UCF\Critical_CSS\API {
+	/**
+	 * Provides the necessary functions for the API
+	 * portion of the plugin.
+	 */
+	class Critical_CSS_API extends \WP_REST_Controller  {
+		/**
+		 * Registers the rest routes for the critical CSS API
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @return void
+		 */
+		public static function register_rest_routes() {
+			$root    = 'ucfccss';
+			$version = 'v1';
+
+			/**
+			 * Rest route responsible for updating a single object
+			 */
+			register_rest_route( "$root/$version", "/update/single", array(
+				'methods'             => \WP_REST_Server::CREATABLE, // Support POST only
+				'callback'            => array( __CLASS__, 'update_single' ),
+				'permission_callback' => array( __CLASS__, 'get_permissions' )
+			) );
+
+			register_rest_route( "$root/$version", "/update/template", array(
+				'methods'             => \WP_REST_Server::EDITABLE, // Support POST only
+				'callback'            => array( __CLASS__, 'update_template' ),
+				'permission_callback' => array( __CLASS__, 'get_permissions' )
+			) );
+		}
+
+		/**
+		 * Determines if the user is allowed to execute
+		 * the functions.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @return bool
+		 */
+		public static function get_permissions() {
+			return true;
+		}
+
+		/**
+		 * Handler for the /update/single endpoint.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param WP_REST_Request The incoming REST request
+		 * @return WP_REST_Response
+		 */
+		public static function update_single( $request ) {
+			$retval = array(
+				'result'  => 'success',
+				'message' => ''
+			);
+
+			$body = $request->get_body();
+			$data = json_decode( $body );
+
+			// Make sure the JSON is valid
+			if ( ! $data ) {
+				$retval['result'] = 'error';
+				$retval['message'] = 'There was an error parsing the request body';
+
+				return new \WP_REST_Response( $retval, 400 );
+			}
+
+			// Make sure we were actually sent CSS
+			if ( $data->result === null ) {
+				$retval['result'] = 'error';
+				$retval['message'] = 'There was no critical css in the request';
+
+				return new \WP_REST_Response( $retval, 400 );
+			}
+
+			// Make sure we know where to write it to
+			$object_type = $data->input->args->meta->object_type;
+			$object_id = $data->input->args->meta->object_id;
+
+			$success = false;
+
+			if ( $object_type === 'post' ) {
+				$success = update_post_meta(
+					$object_id,
+					'object_critical_css',
+					$data->result
+				);
+			} else if ( $object_type === 'term' ) {
+				$success = update_term_meta(
+					$object_id,
+					'object_critical_css',
+					$data->result
+				);
+			}
+
+			if ( $success === false ) {
+				$retval['result'] = 'error';
+				$retval['message'] = "There was an error updating the $object_type meta";
+				return new \WP_REST_Response( $retval, 500 );
+			}
+
+			return new \WP_REST_Response( $data->result, 200 );
+		}
+
+		/**
+		 * Handler for the /update/template endpoint.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param WP_REST_Request The incoming REST request
+		 * @return WP_REST_Response
+		 */
+		public static function update_template( $request ) {
+			$retval = 'Success';
+
+			$body = $request->get_body();
+
+			return new \WP_REST_Response( $retval, 200 );
+		}
+	}
+}

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -17,6 +17,7 @@ namespace UCF\Critical_CSS {
 	define( 'UCF_CRITICAL_CSS__PLUGIN_URL', plugins_url( basename( dirname( __FILE__ ) ) ) );
 	define( 'UCF_CRITICAL_CSS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 	define( 'UCF_CRITICAL_CSS__PLUGIN_FILE', __FILE__ );
+	define( 'UCF_CRITICAL_CSS__MAX_MSG_SIZE', 64000 );
 
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'admin/config.php';
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'admin/actions.php';

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -19,9 +19,16 @@ namespace UCF\Critical_CSS {
 	define( 'UCF_CRITICAL_CSS__PLUGIN_FILE', __FILE__ );
 
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'admin/config.php';
+	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'admin/actions.php';
+	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'admin/utils.php';
 
 	function plugin_init() {
 		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 20, 0 );
+
+		// Register our dynamic filters and actions
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ), 10, 0 );
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'edit_term_actions' ), 10, 0 );
+
 	}
 
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init' );

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -23,6 +23,8 @@ namespace UCF\Critical_CSS {
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'admin/actions.php';
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'admin/utils.php';
 
+	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'api/api.php';
+
 	/**
 	 * Main entry function for the plugin.
 	 * All actions and filters should be registered here
@@ -34,8 +36,10 @@ namespace UCF\Critical_CSS {
 		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 20, 0 );
 
 		// Register our dynamic filters and actions
-		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ), 10, 0 );
-		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'edit_term_actions' ), 10, 0 );
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ) );
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'edit_term_actions' ) );
+
+		add_action( 'rest_api_init', array( 'UCF\Critical_CSS\API\Critical_CSS_API', 'register_rest_routes' ) );
 
 	}
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Critical-CSS-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Critical-CSS-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds the functionality needed to send critical CSS "single" jobs to the critical CSS service. Currently, if a particular post_type or taxonomy has been marked for critical CSS generation, a `save_post_$post_type`, `edit_$taxonomy` or `create_$taxonomy` action is created that will send off the critical CSS generation request when the post/term is saved.

In addition, the API endpoint that would receive the generated CSS has been created.

Note: If code looks like it's placeholder code, it is. 

**Motivation and Context**
This will handle the logic for generating critical CSS for _single_ objects, like posts, pages or terms. A separate process will be used to create more general critical CSS, like for templates or use globally for all instances of a post type or taxonomy.

**How Has This Been Tested?**
Changes have been tested locally, with a demonstration of everything working posted in the appropriate slack channel. Currently, the full process cannot be tested in DEV as it is not accessible to the internet.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
