### PR TITLE
Generation rules

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -12,7 +12,7 @@ namespace UCF\Critical_CSS\Admin {
 		 * @return void
 		 */
 		public static function save_post_actions() {
-			$enabled_post_types = get_field( 'allowed_post_types', 'option' );
+			$enabled_post_types = Utilities::get_critical_css_rules( null, 'post_types' );
 			$generate = get_field( 'enable_critical_css_generation', 'option' );
 
 			if ( ! $enabled_post_types || $generate === false ) return;
@@ -30,7 +30,7 @@ namespace UCF\Critical_CSS\Admin {
 		 * @return void
 		 */
 		 public static function edit_term_actions() {
-			$enabled_taxonomies = get_field( 'allowed_taxonomies', 'option' );
+			$enabled_taxonomies = Utilities::get_critical_css_rules( null, 'taxonomies' );
 			$generate = get_field( 'enable_critical_css_generation', 'option' );
 
 			if ( ! $enabled_taxonomies || $generate === false ) return;

--- a/admin/config.php
+++ b/admin/config.php
@@ -72,7 +72,7 @@ namespace UCF\Critical_CSS\Admin {
 				'instructions'  => 'Select the type of rule to create',
 				'choices'       => array(
 					'individual' => 'Individual Page CSS',
-					'template'   => 'Template Based CSS'
+					'shared'     => 'Shared Template Critical CSS'
 				),
 				'allow_null'    => 0,
 				'multiple'      => 0
@@ -166,7 +166,7 @@ namespace UCF\Critical_CSS\Admin {
 			$fields[] = array(
 				'key'           => 'ucfccss_deferred_rules',
 				'label'         => 'Deferred Rules',
-				'name'          => 'ucfccss_deferred_rules',
+				'name'          => 'deferred_rules',
 				'type'          => 'repeater',
 				'instructions'  => 'The following rules determine when CSS will be deferred and critical CSS generated and inserted, when that feature is active.',
 				'sub_fields'    => $deferred_rules_subfields,
@@ -175,32 +175,6 @@ namespace UCF\Critical_CSS\Admin {
 				'max'           => 10,
 				'layout'        => 'row',
 				'button_label'  => 'Add Rule',
-			);
-
-			$fields[] = array(
-				'key'           => 'ucfccss_allowed_post_types',
-				'label'         => 'Allowed Post Types',
-				'name'          => 'allowed_post_types',
-				'type'          => 'select',
-				'instructions'  => 'Choose the post types for which styles should be deferred.',
-				'choices'       => self::post_types_as_options(),
-				'allow_null'    => 0,
-				'multiple'      => 1,
-				'ui'            => 1,
-				'ajax'          => 1
-			);
-
-			$fields[] = array(
-				'key'           => 'ucfccss_allowed_taxonomies',
-				'label'         => 'Allowed Taxonomies',
-				'name'          => 'allowed_taxonomies',
-				'type'          => 'select',
-				'instructions'  => 'Choose the taxonomies that allow critical CSS generation.',
-				'choices'       => self::taxonomies_as_options(),
-				'allow_null'    => 0,
-				'multiple'      => 1,
-				'ui'            => 1,
-				'ajax'          => 1
 			);
 
 			$fields[] = array(

--- a/admin/config.php
+++ b/admin/config.php
@@ -61,6 +61,122 @@ namespace UCF\Critical_CSS\Admin {
 				'ui_off_text'   => 'Disabled'
 			);
 
+			// Define the subfields for the deferment rules
+			$deferred_rules_subfields = array();
+
+			$deferred_rules_subfields[] = array(
+				'key'           => 'ucfccss_deferred_rules_rule_type',
+				'label'         => 'Rule Type',
+				'name'          => 'rule_type',
+				'type'          => 'select',
+				'instructions'  => 'Select the type of rule to create',
+				'choices'       => array(
+					'individual' => 'Individual Page CSS',
+					'template'   => 'Template Based CSS'
+				),
+				'allow_null'    => 0,
+				'multiple'      => 0
+			);
+
+			$deferred_rules_subfields[] = array(
+				'key'           => 'ucfccss_deferred_rules_object_type',
+				'label'         => 'Object Type',
+				'name'          => 'object_type',
+				'type'          => 'select',
+				'instructions'  => 'Select the object type to apply this rule to',
+				'choices'       => array(
+					'post_type' => 'Post Type',
+					'taxonomy'  => 'Taxonomy',
+					'template'  => 'Template'
+				),
+				'allow_null'    => 0,
+				'multiple'      => 0
+			);
+
+			$deferred_rules_subfields[] = array(
+				'key'               => 'ucfccss_deferred_rules_post_type',
+				'label'             => 'Post Types',
+				'name'              => 'post_types',
+				'type'              => 'select',
+				'instructions'      => 'Choose the post types to apply this rule to',
+				'choices'           => self::post_types_as_options(),
+				'default_value'     => false,
+				'allow_null'        => 0,
+				'multiple'          => 1,
+				'ui'                => 1,
+				'ajax'              => 1,
+				'conditional_logic' => array(
+					array(
+						array(
+							'field'    => 'ucfccss_deferred_rules_object_type',
+							'operator' => '==',
+							'value'    => 'post_type'
+						)
+					)
+				)
+			);
+
+			$deferred_rules_subfields[] = array(
+				'key'               => 'ucfccss_deferred_rules_taxonomies',
+				'label'             => 'Taxonomies',
+				'name'              => 'taxonomies',
+				'type'              => 'select',
+				'instructions'      => 'Choose the taxonomies to apply this rule to',
+				'default_value'     => false,
+				'choices'           => self::taxonomies_as_options(),
+				'default_value'     => false,
+				'allow_null'        => 0,
+				'multiple'          => 1,
+				'ui'                => 1,
+				'ajax'              => 1,
+				'conditional_logic' => array(
+					array(
+						array(
+							'field'    => 'ucfccss_deferred_rules_object_type',
+							'operator' => '==',
+							'value'    => 'taxonomy'
+						)
+					)
+				)
+			);
+
+			$deferred_rules_subfields[] = array(
+				'key'               => 'ucfccss_deferred_rules_templates',
+				'label'             => 'Templates',
+				'name'              => 'templates',
+				'type'              => 'select',
+				'instructions'      => 'Choose the templates to apply this rule to',
+				'default_value'     => false,
+				'choices'           => self::templates_as_options(),
+				'allow_null'        => 0,
+				'multiple'          => 1,
+				'ui'                => 1,
+				'ajax'              => 1,
+				'conditional_logic' => array(
+					array(
+						array(
+							'field'    => 'ucfccss_deferred_rules_object_type',
+							'operator' => '==',
+							'value'    => 'template'
+						)
+					)
+				)
+			);
+
+			$fields[] = array(
+				'key'           => 'ucfccss_deferred_rules',
+				'label'         => 'Deferred Rules',
+				'name'          => 'ucfccss_deferred_rules',
+				'type'          => 'repeater',
+				'instructions'  => 'The following rules determine when CSS will be deferred and critical CSS generated and inserted, when that feature is active.',
+				'sub_fields'    => $deferred_rules_subfields,
+				'collapsed'     => 'ucfccss_deferred_rules_rule_type',
+				'min'           => 1,
+				'max'           => 10,
+				'layout'        => 'row',
+				'button_label'  => 'Add Rule',
+			);
+
 			$fields[] = array(
 				'key'           => 'ucfccss_allowed_post_types',
 				'label'         => 'Allowed Post Types',
@@ -243,6 +359,27 @@ link[rel=\'stylesheet\'][href^=\'//cloud.typography.com/\']'
 
 			foreach( $taxonomies as $tax ) {
 				$retval[$tax->name] = $tax->label;
+			}
+
+			return $retval;
+		}
+
+		/**
+		 * Endeavors to collect all the available templates
+		 * on the theme to return as options.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @return array
+		 */
+		public static function templates_as_options() {
+			$retval = array();
+
+			foreach( self::post_types_as_options() as $post_type => $post_type_label ) {
+				$templates = wp_get_theme()->get_page_templates( null, $post_type );
+
+				foreach( $templates as $template_name => $template_filename ) {
+					$retval[$template_filename] = $template_name;
+				}
 			}
 
 			return $retval;

--- a/admin/config.php
+++ b/admin/config.php
@@ -45,6 +45,7 @@ namespace UCF\Critical_CSS\Admin {
 			 */
 			$fields[] = array(
 				'key'           => 'ucfccss_general_settings_tab',
+				'name'          => '',
 				'label'         => 'General Settings',
 				'type'          => 'tab'
 			);
@@ -191,6 +192,7 @@ namespace UCF\Critical_CSS\Admin {
 			 */
 			$fields[] = array(
 				'key'           => 'ucfccss_critical_css_tab',
+				'name'          => 'name',
 				'label'         => 'Critical CSS Generation',
 				'type'          => 'tab'
 			);

--- a/admin/config.php
+++ b/admin/config.php
@@ -166,7 +166,7 @@ namespace UCF\Critical_CSS\Admin {
 			$fields[] = array(
 				'key'           => 'ucfccss_deferred_rules',
 				'label'         => 'Deferred Rules',
-				'name'          => 'deferred_rules',
+				'name'          => 'ucfccss_deferred_rules',
 				'type'          => 'repeater',
 				'instructions'  => 'The following rules determine when CSS will be deferred and critical CSS generated and inserted, when that feature is active.',
 				'sub_fields'    => $deferred_rules_subfields,
@@ -175,6 +175,7 @@ namespace UCF\Critical_CSS\Admin {
 				'max'           => 10,
 				'layout'        => 'row',
 				'button_label'  => 'Add Rule',
+				''
 			);
 
 			$fields[] = array(
@@ -351,7 +352,7 @@ link[rel=\'stylesheet\'][href^=\'//cloud.typography.com/\']'
 			foreach( self::post_types_as_options() as $post_type => $post_type_label ) {
 				$templates = wp_get_theme()->get_page_templates( null, $post_type );
 
-				foreach( $templates as $template_name => $template_filename ) {
+				foreach( $templates as $template_filename => $template_name ) {
 					$retval[$template_filename] = $template_name;
 				}
 			}
@@ -374,6 +375,54 @@ link[rel=\'stylesheet\'][href^=\'//cloud.typography.com/\']'
 			</div>
 		<?php
 			echo ob_get_clean();
+		}
+
+		/**
+		 * Helper function to clean up old values in the deferred rules field
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param string The ID of the post being saved.
+		 * @return void
+		 */
+		public static function clean_deferred_rules( $post_id ) {
+			if ( $post_id !== 'options' ) return;
+
+			$rules = get_field( 'ucfccss_deferred_rules', 'option' );
+
+			// These are not the fields we're looking for...
+			if ( ! $rules ) return;
+
+			foreach( $rules as $idx => $rule ) {
+				switch( $rule['object_type'] ) {
+					case 'post_type':
+						if ( get_option( "options_ucfccss_deferred_rules_{$idx}_taxonomies" , null) !== null ) {
+							delete_option( "options_ucfccss_deferred_rules_{$idx}_taxonomies" );
+							delete_option( "_options_ucfccss_deferred_rules_{$idx}_taxonomies" );
+						} else if ( get_option( "options_ucfccss_deferred_rules_{$idx}_templates", null ) !== null ) {
+							delete_option( "options_ucfccss_deferred_rules_{$idx}_templates" );
+							delete_option( "_options_ucfccss_deferred_rules_{$idx}_templates" );
+						}
+						break;
+					case 'taxonomy':
+						if ( get_option( "options_ucfccss_deferred_rules_{$idx}_post_types", null ) === null ) {
+							delete_option( "options_ucfccss_deferred_rules_{$idx}_post_types" );
+							delete_option( "_options_ucfccss_deferred_rules_{$idx}_post_types" );
+						} else if ( get_option( "options_ucfccss_deferred_rules_{$idx}_templates", null ) !== null ) {
+							delete_option( "options_ucfccss_deferred_rules_{$idx}_templates" );
+							delete_option( "_options_ucfccss_deferred_rules_{$idx}_templates" );
+						}
+						break;
+					case 'template':
+						if ( get_option( "options_ucfccss_deferred_rules_{$idx}_post_types", null ) !== null ) {
+							delete_option( "options_ucfccss_deferred_rules_{$idx}_post_types" );
+							delete_option( "_options_ucfccss_deferred_rules_{$idx}_post_types" );
+						} else if ( get_option( "options_ucfccss_deferred_rules_{$idx}_taxonomies", null ) !== null ) {
+							delete_option( "options_ucfccss_deferred_rules_{$idx}_taxonomies" );
+							delete_option( "_options_ucfccss_deferred_rules_{$idx}_taxonomies" );
+						}
+						break;
+				}
+			}
 		}
 	}
 }

--- a/admin/config.php
+++ b/admin/config.php
@@ -192,7 +192,7 @@ namespace UCF\Critical_CSS\Admin {
 			 */
 			$fields[] = array(
 				'key'           => 'ucfccss_critical_css_tab',
-				'name'          => 'name',
+				'name'          => '',
 				'label'         => 'Critical CSS Generation',
 				'type'          => 'tab'
 			);

--- a/admin/config.php
+++ b/admin/config.php
@@ -21,7 +21,7 @@ namespace UCF\Critical_CSS\Admin {
 					'redirect'    => false
 				) );
 
-				add_action( 'acf/init', array( __CLASS__, 'add_options_page_fields' ) );
+				self::add_options_page_fields();
 
 			} else {
 				add_action( 'admin_notices', array( __NAMESPACE__ . '\Config', 'no_acf_admin_notice' ) );

--- a/admin/config.php
+++ b/admin/config.php
@@ -21,7 +21,7 @@ namespace UCF\Critical_CSS\Admin {
 					'redirect'    => false
 				) );
 
-				self::add_options_page_fields();
+				add_action( 'acf/init', array( __CLASS__, 'add_options_page_fields' ) );
 
 			} else {
 				add_action( 'admin_notices', array( __NAMESPACE__ . '\Config', 'no_acf_admin_notice' ) );

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -171,6 +171,8 @@ namespace UCF\Critical_CSS\Admin {
 
 			$rules = get_field( 'ucfccss_deferred_rules', 'option' );
 
+			if ( ! is_array( $rules ) ) return null;
+
 			foreach( $rules as $rule ) {
 				if ( $rule['rule_type'] === 'individual' ) {
 					if ( $rule['object_type'] === 'post_type' ) {

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -237,7 +237,7 @@ namespace UCF\Critical_CSS\Admin {
 
 			foreach( $rules as $rule ) {
 				// Handle individual and shared first
-				if ( $is_post && in_array( $post_type, $rule['post_types'] ) ) {
+				if ( $is_post && isset( $rule['post_types'] ) && in_array( $post_type, $rule['post_types'] ) ) {
 					if ( $rule['rule_type'] === 'individual' ) {
 						return array(
 							'object_type' => 'post_meta',
@@ -249,7 +249,7 @@ namespace UCF\Critical_CSS\Admin {
 							'object_name' => "ucfccss_post_type_{$post_type}_critical_css"
 						);
 					}
-				} else if ( ! $is_post && in_array( $taxonomy, $rule['taxonomies'] ) ) {
+				} else if ( ! $is_post && isset( $rule['taxonomies'] ) && in_array( $taxonomy, $rule['taxonomies'] ) ) {
 					if ( $rule['rule_type'] === 'individual' ) {
 						return array(
 							'object_type' => 'term_meta',
@@ -263,7 +263,7 @@ namespace UCF\Critical_CSS\Admin {
 					}
 				}
 
-				if ( $is_post && in_array( $template, $rule['templates'] ) ) {
+				if ( $is_post && isset( $rule['templates'] ) && in_array( $template, $rule['templates'] ) ) {
 					if ( $rule['rule_type'] === 'individual' ) {
 						return array(
 							'object_type' => 'post_meta',

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -237,7 +237,7 @@ namespace UCF\Critical_CSS\Admin {
 
 			foreach( $rules as $rule ) {
 				// Handle individual and shared first
-				if ( $is_post && isset( $rule['post_types'] ) && in_array( $post_type, $rule['post_types'] ) ) {
+				if ( $is_post && is_array( $rule['post_types'] ) && in_array( $post_type, $rule['post_types'] ) ) {
 					if ( $rule['rule_type'] === 'individual' ) {
 						return array(
 							'object_type' => 'post_meta',
@@ -249,7 +249,7 @@ namespace UCF\Critical_CSS\Admin {
 							'object_name' => "ucfccss_post_type_{$post_type}_critical_css"
 						);
 					}
-				} else if ( ! $is_post && isset( $rule['taxonomies'] ) && in_array( $taxonomy, $rule['taxonomies'] ) ) {
+				} else if ( ! $is_post && is_array( $rule['taxonomies'] ) &&  in_array( $taxonomy, $rule['taxonomies'] ) ) {
 					if ( $rule['rule_type'] === 'individual' ) {
 						return array(
 							'object_type' => 'term_meta',
@@ -263,7 +263,7 @@ namespace UCF\Critical_CSS\Admin {
 					}
 				}
 
-				if ( $is_post && isset( $rule['templates'] ) && in_array( $template, $rule['templates'] ) ) {
+				if ( $is_post && is_array( $rule['templates'] ) && in_array( $template, $rule['templates'] ) ) {
 					if ( $rule['rule_type'] === 'individual' ) {
 						return array(
 							'object_type' => 'post_meta',

--- a/api/api.php
+++ b/api/api.php
@@ -109,7 +109,9 @@ namespace UCF\Critical_CSS\API {
 			}
 
 			// Delete the transient
-			delete_transient( $csrf );
+			if ( $csrf ) {
+				delete_transient( $csrf );
+			}
 
 			if ( $success === false ) {
 				$retval['result'] = 'error';

--- a/includes/critical-css.php
+++ b/includes/critical-css.php
@@ -1,0 +1,46 @@
+<?php
+namespace UCF\Critical_CSS\Includes\Critical_CSS {
+
+	/**
+	 * Returns stored critical CSS to utilize for the provided
+	 * post/term object.
+	 *
+	 * @since 0.1.0
+	 * @author Jo Dickson
+	 * @param object $obj WordPress post or term object; defaults to the
+	 *                    current queried object if not provided
+	 * @return string
+	 */
+	function get_critical_css( $obj=null ) {
+		if ( ! $obj ) {
+			$obj = get_queried_object();
+		}
+		if ( ! $obj ) return '';
+
+		// TODO will need to add some logic here that determines
+		// if generic post/term template critical CSS should be
+		// returned instead of object-specific critical CSS
+
+		return get_field( 'object_critical_css', $obj );
+	}
+
+	/**
+	 * Inserts critical CSS for the provided post/term object
+	 * into the document <head>.
+	 *
+	 * For use with the `wp_head` action hook.
+	 *
+	 * @since 0.1.0
+	 * @author Jo Dickson
+	 * @return void
+	 */
+	function insert_in_head() {
+		$critical_css = get_critical_css();
+		if ( $critical_css ) :
+	?>
+<style id="ucfccss-critical-css"><?php echo $critical_css; ?></style>
+	<?php
+		endif;
+	}
+
+}

--- a/includes/critical-css.php
+++ b/includes/critical-css.php
@@ -1,6 +1,8 @@
 <?php
 namespace UCF\Critical_CSS\Includes\Critical_CSS {
 
+	use UCF\Critical_CSS\Admin;
+
 	/**
 	 * Returns stored critical CSS to utilize for the provided
 	 * post/term object.
@@ -17,11 +19,21 @@ namespace UCF\Critical_CSS\Includes\Critical_CSS {
 		}
 		if ( ! $obj ) return '';
 
-		// TODO will need to add some logic here that determines
-		// if generic post/term template critical CSS should be
-		// returned instead of object-specific critical CSS
+		$match = Admin\Utilities::get_matching_rule( $obj );
 
-		return get_field( 'object_critical_css', $obj );
+		if ( $match ) {
+			switch( $match['object_type'] ) {
+				case 'post_meta':
+					return get_post_meta( $obj->ID, $match['object_name'] );
+				case 'term_meta':
+					return get_term_meta( $obj->term_id, $match['object_name'] );
+				case 'transient':
+					// TODO: Add in logic for generating the transient when it expires.
+					return get_transient( $match['object_name'] );
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/critical-css.php
+++ b/includes/critical-css.php
@@ -24,12 +24,14 @@ namespace UCF\Critical_CSS\Includes\Critical_CSS {
 		if ( $match ) {
 			switch( $match['object_type'] ) {
 				case 'post_meta':
-					return get_post_meta( $obj->ID, $match['object_name'] );
+					return get_post_meta( $obj->ID, $match['object_name'], true );
 				case 'term_meta':
-					return get_term_meta( $obj->term_id, $match['object_name'] );
+					return get_term_meta( $obj->term_id, $match['object_name'], true );
 				case 'transient':
 					// TODO: Add in logic for generating the transient when it expires.
 					return get_transient( $match['object_name'] );
+				default:
+					break;
 			}
 		}
 

--- a/includes/deferred-styles.php
+++ b/includes/deferred-styles.php
@@ -12,10 +12,7 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 	 * @return boolean
 	 */
 	function enabled_globally() {
-		return true;
-		// TODO get_field( 'enable_deferred_styles_global', 'option' ) results
-		// in a critical error with the UCF FAQ plugin for some bizarre reason
-		// return filter_var( get_field( 'enable_deferred_styles_global', 'option' ), FILTER_VALIDATE_BOOLEAN );
+		return filter_var( get_field( 'enable_deferred_styles_global', 'option' ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**

--- a/includes/deferred-styles.php
+++ b/includes/deferred-styles.php
@@ -34,7 +34,7 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 
 		if ( $critical_css ) {
 			$exclude_option = get_field( 'deferred_exceptions', 'option' );
-			$exclude = $exclude_option ? array_filter( array_map( 'trim', explode( '\n', $exclude_option ) ) ) : array();
+			$exclude = $exclude_option ? array_filter( array_map( 'trim', explode( "\n", $exclude_option ) ) ) : array();
 
 			if ( ! in_array( $handle, $exclude ) && $media !== 'print' ) {
 				$media_replaced = str_replace( 'media=\'' . $media . '\'', 'media=\'print\' onload=\'this.media="' . $media . '"\'', $html );

--- a/includes/deferred-styles.php
+++ b/includes/deferred-styles.php
@@ -1,0 +1,48 @@
+<?php
+namespace UCF\Critical_CSS\Includes\Deferred_Styles {
+
+	use UCF\Critical_CSS\Includes\Critical_CSS;
+
+	/**
+	 * Returns whether or not deferred style usage is enabled
+	 * at the plugin level.
+	 *
+	 * @since 0.1.0
+	 * @author Jo Dickson
+	 * @return boolean
+	 */
+	function enabled_globally() {
+		return filter_var( get_field( 'ucfccss_enable_deferred_styles_global', 'option' ), FILTER_VALIDATE_BOOLEAN );
+	}
+
+	/**
+	 * Action that modifies enqueued stylesheets to load asynchronously
+	 * when critical CSS is available for the queried object.
+	 *
+	 * For use with the `style_loader_tag` action hook.
+	 *
+	 * @since 0.1.0
+	 * @author Jo Dickson
+	 * @param string $html The link tag for the enqueued style.
+	 * @param string $handle The style's registered handle.
+	 * @param string $href The stylesheet's source URL.
+	 * @param string $media The stylesheet's media attribute.
+	 * @return string The modified link tag markup
+	*/
+	function defer_enqueued_styles( $html, $handle, $href, $media ) {
+		$critical_css = Critical_CSS\get_critical_css();
+
+		if ( $critical_css ) {
+			$exclude_option = get_field( 'ucfccss_deferred_exceptions', 'option' );
+			$exclude = $exclude_option ? array_filter( array_map( 'trim', explode( '\n', $exclude_option ) ) ) : array();
+
+			if ( ! in_array( $handle, $exclude ) && $media !== 'print' ) {
+				$media_replaced = str_replace( 'media=\'' . $media . '\'', 'media=\'print\' onload=\'this.media="' . $media . '"\'', $html );
+				$html = $media_replaced . '<noscript>' . $html . '</noscript>';
+			}
+		}
+
+		return $html;
+	}
+
+}

--- a/includes/deferred-styles.php
+++ b/includes/deferred-styles.php
@@ -12,7 +12,10 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 	 * @return boolean
 	 */
 	function enabled_globally() {
-		return filter_var( get_field( 'ucfccss_enable_deferred_styles_global', 'option' ), FILTER_VALIDATE_BOOLEAN );
+		return true;
+		// TODO get_field( 'enable_deferred_styles_global', 'option' ) results
+		// in a critical error with the UCF FAQ plugin for some bizarre reason
+		// return filter_var( get_field( 'enable_deferred_styles_global', 'option' ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
@@ -33,7 +36,7 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 		$critical_css = Critical_CSS\get_critical_css();
 
 		if ( $critical_css ) {
-			$exclude_option = get_field( 'ucfccss_deferred_exceptions', 'option' );
+			$exclude_option = get_field( 'deferred_exceptions', 'option' );
 			$exclude = $exclude_option ? array_filter( array_map( 'trim', explode( '\n', $exclude_option ) ) ) : array();
 
 			if ( ! in_array( $handle, $exclude ) && $media !== 'print' ) {

--- a/includes/deferred-styles.php
+++ b/includes/deferred-styles.php
@@ -12,7 +12,7 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 	 * @return boolean
 	 */
 	function enabled_globally() {
-		return filter_var( get_field( 'enable_deferred_styles_global', 'option' ), FILTER_VALIDATE_BOOLEAN );
+		return filter_var( get_option( 'options_enable_deferred_styles_global' ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
@@ -33,7 +33,7 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 		$critical_css = Critical_CSS\get_critical_css();
 
 		if ( $critical_css ) {
-			$exclude_option = get_field( 'deferred_exceptions', 'option' );
+			$exclude_option = get_option( 'options_deferred_exceptions' );
 			$exclude = $exclude_option ? array_filter( array_map( 'trim', explode( "\n", $exclude_option ) ) ) : array();
 
 			if ( ! in_array( $handle, $exclude ) && $media !== 'print' ) {

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -39,10 +39,11 @@ namespace UCF\Critical_CSS {
 	 */
 	function plugin_init() {
 		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 20, 0 );
+		add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 20, 1 );
 
 		// Register our dynamic filters and actions
-		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ) );
-		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'edit_term_actions' ) );
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ), 20, 0 );
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'edit_term_actions' ), 20, 0 );
 
 		add_action( 'rest_api_init', array( 'UCF\Critical_CSS\API\Critical_CSS_API', 'register_rest_routes' ) );
 

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -10,6 +10,8 @@ GitHub Plugin URI: UCF/UCF-Critical-CSS-Plugin
 
 namespace UCF\Critical_CSS {
 
+	use UCF\Critical_CSS\Includes\Deferred_Styles;
+
 	if ( ! defined( 'WPINC' ) ) {
 		die;
 	}
@@ -19,6 +21,9 @@ namespace UCF\Critical_CSS {
 	define( 'UCF_CRITICAL_CSS__PLUGIN_FILE', __FILE__ );
 
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'admin/config.php';
+	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/critical-css.php';
+	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/deferred-styles.php';
+
 
 	/**
 	 * Main entry function for the plugin.
@@ -29,7 +34,13 @@ namespace UCF\Critical_CSS {
 	 */
 	function plugin_init() {
 		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 20, 0 );
+
+		if ( Deferred_Styles\enabled_globally() ) {
+			add_action( 'wp_head', 'UCF\Critical_CSS\Includes\Critical_CSS\insert_in_head', 1 );
+			add_action( 'style_loader_tag', 'UCF\Critical_CSS\Includes\Deferred_Styles\async_enqueued_styles', 99, 4 );
+		}
 	}
 
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init' );
+
 }

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -39,7 +39,7 @@ namespace UCF\Critical_CSS {
 	 */
 	function plugin_init() {
 		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 20, 0 );
-		add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 20, 1 );
+		// add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 20, 1 );
 
 		// Register our dynamic filters and actions
 		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ), 20, 0 );

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -48,7 +48,7 @@ namespace UCF\Critical_CSS {
 
 		if ( Deferred_Styles\enabled_globally() ) {
 			add_action( 'wp_head', 'UCF\Critical_CSS\Includes\Critical_CSS\insert_in_head', 1 );
-			add_action( 'style_loader_tag', 'UCF\Critical_CSS\Includes\Deferred_Styles\async_enqueued_styles', 99, 4 );
+			add_action( 'style_loader_tag', 'UCF\Critical_CSS\Includes\Deferred_Styles\defer_enqueued_styles', 99, 4 );
 		}
 	}
 

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -38,12 +38,12 @@ namespace UCF\Critical_CSS {
 	 * @return void
 	 */
 	function plugin_init() {
-		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 20, 0 );
-		// add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 20, 1 );
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 10, 0 );
+		add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 20, 1 );
 
 		// Register our dynamic filters and actions
-		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ), 20, 0 );
-		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'edit_term_actions' ), 20, 0 );
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ), 10, 0 );
+		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'edit_term_actions' ), 10, 0 );
 
 		add_action( 'rest_api_init', array( 'UCF\Critical_CSS\API\Critical_CSS_API', 'register_rest_routes' ) );
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Critical-CSS-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Critical-CSS-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a new set of configuration rules that allows for the generation and serving up of critical CSS to be triggered by a couple of factors:

1. Critical CSS can be generated and stored for each individual object 
2. Critical CSS can be generated and shared across a common post_type, taxonomy or template

Mixing and matching these settings can allow for some specific behaviors. For example, if we wanted to use shared critical CSS across all degree pages, but individual critical CSS for pages using the "Custom Degree" template, and then individual critical CSS for all other pages, we could add the rules in the following order:

| Rule Type | Object Type | Values |
|---|---|---|
| Individual | Template | Custom Degree |
| Shared | Post Type | Degree |
| Individual | Post Type | Page |

This pull request also adds the initial logic for deferring CSS styles and inserting the critical CSS onto the page - huzzah @cjg89 on getting that done! 

The generation and insertion of critical CSS for "shared" critical CSS is currently not working, but will be added in the next pull request that goes up.

**Motivation and Context**
The change in settings allows for flexibility in the way the critical CSS is created and consumed, hopefully reducing the amount of critical CSS we're having to create and keep track of.

**How Has This Been Tested?**
The rules for generating and serving up "individual" CSS rules has been fully tested locally and is working.

An example of the deferred CSS logic and the critical CSS can be seen on the DEV homepage. Also, an example of a set of generation rules can be found in the "UCF Critical CSS" settings page.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
