### PR TITLE
Hook Timing

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -13,7 +13,7 @@ namespace UCF\Critical_CSS\Admin {
 		 */
 		public static function save_post_actions() {
 			$enabled_post_types = Utilities::get_critical_css_rules( null, 'post_types' );
-			$generate = get_field( 'enable_critical_css_generation', 'option' );
+			$generate = filter_var( get_option( 'enable_critical_css_generation', 'option' ), FILTER_VALIDATE_BOOLEAN );
 
 			if ( ! $enabled_post_types || $generate === false ) return;
 
@@ -31,7 +31,7 @@ namespace UCF\Critical_CSS\Admin {
 		 */
 		 public static function edit_term_actions() {
 			$enabled_taxonomies = Utilities::get_critical_css_rules( null, 'taxonomies' );
-			$generate = get_field( 'enable_critical_css_generation', 'option' );
+			$generate = filter_var( get_option( 'enable_critical_css_generation' ), FILTER_VALIDATE_BOOLEAN );
 
 			if ( ! $enabled_taxonomies || $generate === false ) return;
 

--- a/admin/config.php
+++ b/admin/config.php
@@ -21,8 +21,6 @@ namespace UCF\Critical_CSS\Admin {
 					'redirect'    => false
 				) );
 
-				self::add_options_page_fields();
-
 			} else {
 				add_action( 'admin_notices', array( __NAMESPACE__ . '\Config', 'no_acf_admin_notice' ) );
 			}
@@ -100,7 +98,7 @@ namespace UCF\Critical_CSS\Admin {
 				'name'              => 'post_types',
 				'type'              => 'select',
 				'instructions'      => 'Choose the post types to apply this rule to',
-				'choices'           => self::post_types_as_options(),
+				'choices'           => array(),
 				'default_value'     => false,
 				'allow_null'        => 0,
 				'multiple'          => 1,
@@ -124,7 +122,7 @@ namespace UCF\Critical_CSS\Admin {
 				'type'              => 'select',
 				'instructions'      => 'Choose the taxonomies to apply this rule to',
 				'default_value'     => false,
-				'choices'           => self::taxonomies_as_options(),
+				'choices'           => array(),
 				'default_value'     => false,
 				'allow_null'        => 0,
 				'multiple'          => 1,
@@ -148,7 +146,7 @@ namespace UCF\Critical_CSS\Admin {
 				'type'              => 'select',
 				'instructions'      => 'Choose the templates to apply this rule to',
 				'default_value'     => false,
-				'choices'           => self::templates_as_options(),
+				'choices'           => array(),
 				'allow_null'        => 0,
 				'multiple'          => 1,
 				'ui'                => 1,
@@ -306,7 +304,7 @@ link[rel=\'stylesheet\'][href^=\'//cloud.typography.com/\']'
 			$retval = array();
 
 			$args = array(
-				'public' => true
+				'public'  => true
 			);
 
 			$post_types = get_post_types( $args, 'objects' );
@@ -360,6 +358,45 @@ link[rel=\'stylesheet\'][href^=\'//cloud.typography.com/\']'
 			}
 
 			return $retval;
+		}
+
+		/**
+		 * Function for setting the choices for the
+		 * ucfccss_deferred_rules_post_type field.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param array $field The ACF Field
+		 * @return array The ACF Field
+		 */
+		public static function get_post_types_choices( $field ) {
+			$field['choices'] = self::post_types_as_options();
+			return $field;
+		}
+
+		/**
+		 * Function for setting the choices for the
+		 * ucfccss_deferred_rules_taxonomies field.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param array $field The ACF Field
+		 * @return array The ACF Field
+		 */
+		public static function get_taxonomies_choices( $field ) {
+			$field['choices'] = self::taxonomies_as_options();
+			return $field;
+		}
+
+		/**
+		 * Function for setting the choices for the
+		 * ucfccss_deferred_rules_templates field.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param array $field The ACF Field
+		 * @return array The ACF Field
+		 */
+		public static function get_templates_choices( $field ) {
+			$field['choices'] = self::templates_as_options();
+			return $field;
 		}
 
 		/**

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -38,7 +38,7 @@ namespace UCF\Critical_CSS {
 	 * @return void
 	 */
 	function plugin_init() {
-		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 10, 0 );
+		add_action( 'acf/init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 10, 0 );
 		add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 20, 1 );
 
 		// Register our dynamic filters and actions
@@ -51,8 +51,24 @@ namespace UCF\Critical_CSS {
 			add_action( 'wp_head', 'UCF\Critical_CSS\Includes\Critical_CSS\insert_in_head', 1 );
 			add_action( 'style_loader_tag', 'UCF\Critical_CSS\Includes\Deferred_Styles\defer_enqueued_styles', 99, 4 );
 		}
+
+		add_action(
+			'acf/init',
+			array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page_fields') , 10, 0 );
+
+		add_filter(
+			'acf/load_field/key=ucfccss_deferred_rules_post_type',
+			array( 'UCF\Critical_CSS\Admin\Config', 'get_post_types_choices' ), 10, 1 );
+
+		add_filter(
+			'acf/load_field/key=ucfccss_deferred_rules_taxonomies',
+			array( 'UCF\Critical_CSS\Admin\Config', 'get_taxonomies_choices' ), 10, 1 );
+
+		add_filter(
+			'acf/load_field/key=ucfccss_deferred_rules_templates',
+			array( 'UCF\Critical_CSS\Admin\Config', 'get_templates_choices' ), 10, 1 );
 	}
 
-	add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init' );
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init', 99, 0 );
 
 }


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Critical-CSS-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Critical-CSS-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adjusted when various hooks are called so the options page fields are loaded late in the WordPress lifecycle.

**Motivation and Context**
Without the late timing, the options aren't able to pick up on all the post_types, taxonomies, templates and other goodies that we load in all our other plugins and themes.

**How Has This Been Tested?**
Changes can be checked out in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
