### PR TITLE
Shared critical css

### DIFF
--- a/admin/actions.php
+++ b/admin/actions.php
@@ -13,7 +13,7 @@ namespace UCF\Critical_CSS\Admin {
 		 */
 		public static function save_post_actions() {
 			$enabled_post_types = Utilities::get_critical_css_rules( null, 'post_types' );
-			$generate = filter_var( get_option( 'enable_critical_css_generation', 'option' ), FILTER_VALIDATE_BOOLEAN );
+			$generate = filter_var( get_field( 'enable_critical_css_generation', 'option' ), FILTER_VALIDATE_BOOLEAN );
 
 			if ( ! $enabled_post_types || $generate === false ) return;
 
@@ -31,7 +31,7 @@ namespace UCF\Critical_CSS\Admin {
 		 */
 		 public static function edit_term_actions() {
 			$enabled_taxonomies = Utilities::get_critical_css_rules( null, 'taxonomies' );
-			$generate = filter_var( get_option( 'enable_critical_css_generation' ), FILTER_VALIDATE_BOOLEAN );
+			$generate = filter_var( get_field( 'enable_critical_css_generation', 'option' ), FILTER_VALIDATE_BOOLEAN );
 
 			if ( ! $enabled_taxonomies || $generate === false ) return;
 

--- a/admin/config.php
+++ b/admin/config.php
@@ -233,6 +233,15 @@ namespace UCF\Critical_CSS\Admin {
 link[rel=\'stylesheet\'][href^=\'//cloud.typography.com/\']'
 			);
 
+			$fields[] = array(
+				'key'           => 'ucfccss_shared_css_expiration',
+				'label'         => 'Shared Critical CSS Expiration (Minutes)',
+				'name'          => 'shared_css_expiration',
+				'type'          => 'number',
+				'instructions'  => 'The amount of time shared Critical CSS should be cached for in minutes.',
+				'default_value' => 1440 // One day
+			);
+
 			/**
 			 * Define the sub fields for the dimension repeater
 			 */

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -74,7 +74,9 @@ namespace UCF\Critical_CSS\Admin {
 							! $exp ||
 							( $css && $exp <= $now )
 						) {
-							\WP_CLI::log( 'Generating {$css_object_key}...' );
+							if ( defined( 'WP_CLI' ) && WP_CLI ) {
+								\WP_CLI::log( "Generating {$css_object_key}" );
+							}
 							$object = self::get_first_object_matching_rule( $rule['object_type'], $value );
 
 							if ( $object ) {

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -36,6 +36,110 @@ namespace UCF\Critical_CSS\Admin {
 		}
 
 		/**
+		 * Loops through the critical CSS rules and makes requests
+		 * for any shared critical CSS values that need to be refreshed.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @return void
+		 */
+		public static function update_shared_critical_css() {
+			$now = time();
+			$rules = get_field( 'ucfccss_deferred_rules', 'option' );
+
+			$value_key_lookup = array(
+				'post_type' => 'post_types',
+				'taxonomy'  => 'taxonomies',
+				'template'  => 'templates'
+			);
+
+			foreach( $rules as $rule ) {
+				if ( $rule['rule_type'] === 'shared' ) {
+
+					$value_key = isset( $value_key_lookup[$rule['object_type']] ) ?
+						$value_key_lookup[$rule['object_type']] :
+						null;
+
+					if ( ! $value_key ) continue;
+
+					foreach( $rule[$value_key] as $value ) {
+						// Returns the name of the rule we need to check.
+						$css_object_key = self::get_shared_rule_name( $rule['object_type'], $value );
+						$css_object_exp = "{$css_object_key}_expiration";
+
+						$css = get_option( $css_object_key, null );
+						$exp = get_option( $css_object_exp, null );
+
+						if (
+							! $css ||
+							! $exp ||
+							( $css && $exp <= $now )
+						) {
+							\WP_CLI::log( 'Generating {$css_object_key}...' );
+							$object = self::get_first_object_matching_rule( $rule['object_type'], $value );
+
+							if ( $object ) {
+								$object_url = $rule['object_type'] === 'taxonomy' ?
+									get_term_link( $object ) :
+									get_permalink( $object );
+
+								self::request_shared_critical_css( $css_object_key, $object_url );
+							}
+						}
+					}
+				}
+			}
+		}
+
+		/**
+		 * Returns the option name for shared rules
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param string $object_type The object type: post_type, taxonomy or template
+		 * @param string $object_value The specific post_type, taxonomy or template
+		 */
+		public static function get_shared_rule_name( $object_type, $object_value ) {
+			return "ucfccss_{$object_type}_{$object_value}_critical_css";
+		}
+
+		/**
+		 * Returns the first post or term based on the input
+		 * parameters.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param
+		 */
+		public static function get_first_object_matching_rule( $object_type, $object_value ) {
+			$retval = null;
+
+			if ( in_array( $object_type, array( 'post_type', 'template' ) ) ) {
+				$args = array(
+					'posts_per_page' => 1,
+				);
+
+				if ( $object_type === 'post_type' ) {
+					$args['post_type'] = $object_value;
+				} else if ( $object_type === 'template' ) {
+					$args['meta_key']   = '_wp_page_template';
+					$args['meta_value'] = $object_value;
+				}
+
+				$results = get_posts( $args );
+				$retval = count( $results ) > 0 ? $results[0] : null;
+
+			} else if ( $object_type === 'taxonomy' ) {
+				$args = array(
+					'number'   => 1,
+					'taxonomy' => $object_value
+				);
+
+				$results = get_terms( $args );
+				$retval = count( $results ) > 0 ? $results[0] : null;
+			}
+
+			return $retval;
+		}
+
+		/**
 		 * Requests critical CSS to be generated for a
 		 * post or term.
 		 * @author Jim Barnes
@@ -84,6 +188,50 @@ namespace UCF\Critical_CSS\Admin {
 			}
 
 			$request_body = self::build_critical_css_request( $html, $url, $meta );
+			$request_url = get_field( 'critical_css_service_url', 'option' );
+			$request_key = get_field( 'critical_css_service_key', 'option' );
+
+			$request_args = array(
+				'body' => $request_body
+			);
+
+			// Add the request_key if one exists
+			if ( ! empty( $request_key ) ) {
+				$request_args['headers'] = array(
+					'x-functions-key' => $request_key
+				);
+			}
+
+			$response = wp_remote_post( $request_url, $request_args );
+
+			if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
+				error_log( 'Failed to enqueue critical css request' );
+			}
+		}
+
+		/**
+		 * Generated a request to generate shared critical CSS
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param string $object_key The key to use when storing the CSS
+		 * @param string $url The URL to use to generate the critical CSS
+		 * @return void
+		 */
+		public static function request_shared_critical_css( $object_key, $url ) {
+			$meta = array(
+				'response_url' => get_rest_url( null, 'ucfccss/v1/update/shared/' ), // The url of the API. Leaving blank for now.
+				'object_type'  => 'shared',
+				'object_id'    => $object_key
+			);
+
+			$transient_key = 'ucfccss_csrf__' . md5( "{$meta['object_type']}__{$meta['object_id']}" );
+
+			$meta['csrf'] = $transient_key;
+
+			set_transient( $transient_key, $meta, 1200 );
+
+			// Null html for all shared requests
+			$request_body = self::build_critical_css_request( null, $url, $meta );
 			$request_url = get_field( 'critical_css_service_url', 'option' );
 			$request_key = get_field( 'critical_css_service_key', 'option' );
 

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -393,7 +393,7 @@ namespace UCF\Critical_CSS\Admin {
 						);
 					} else if ( $rule['rule_type'] === 'shared' ) {
 						return array(
-							'object_type' => 'transient',
+							'object_type' => 'option',
 							'object_name' => "ucfccss_post_type_{$post_type}_critical_css"
 						);
 					}
@@ -405,7 +405,7 @@ namespace UCF\Critical_CSS\Admin {
 						);
 					} else if ( $rule['rule_type'] === 'shared' ) {
 						return array(
-							'object_type' => 'transient',
+							'object_type' => 'option',
 							'object_name' => "ucfccss_taxonomy_{$taxonomy}_critical_css"
 						);
 					}
@@ -419,7 +419,7 @@ namespace UCF\Critical_CSS\Admin {
 						);
 					} else if ( $rule['rule_type'] === 'shared' ) {
 						return array(
-							'object_type' => 'transient',
+							'object_type' => 'option',
 							'object_name' => "ucfccss_template_{$template}_critical_css"
 						);
 					}

--- a/api/api.php
+++ b/api/api.php
@@ -130,7 +130,7 @@ namespace UCF\Critical_CSS\API {
 		 * @return WP_REST_Response
 		 */
 		public static function update_shared( $request ) {
-			$exp_span = get_field( 'shared_css_expiration' );
+			$exp_span = intval( get_option( 'shared_css_expiration', 1440 ) );
 			$exp_time = time() + ( $exp_span * 60 ); // Multiply by 60 to convert to seconds.
 
 			$retval = array(

--- a/api/api.php
+++ b/api/api.php
@@ -130,7 +130,8 @@ namespace UCF\Critical_CSS\API {
 		 * @return WP_REST_Response
 		 */
 		public static function update_shared( $request ) {
-			$exp_time = time() + ( 24 * 60 * 60 );
+			$exp_span = get_field( 'shared_css_expiration' );
+			$exp_time = time() + ( $exp_span * 60 ); // Multiply by 60 to convert to seconds.
 
 			$retval = array(
 				'result'  => 'success',

--- a/api/api.php
+++ b/api/api.php
@@ -24,9 +24,9 @@ namespace UCF\Critical_CSS\API {
 				'permission_callback' => array( __CLASS__, 'get_permissions' )
 			) );
 
-			register_rest_route( "$root/$version", "/update/template", array(
+			register_rest_route( "$root/$version", "/update/shared", array(
 				'methods'             => \WP_REST_Server::EDITABLE, // Support POST only
-				'callback'            => array( __CLASS__, 'update_template' ),
+				'callback'            => array( __CLASS__, 'update_shared' ),
 				'permission_callback' => array( __CLASS__, 'get_permissions' )
 			) );
 		}
@@ -119,7 +119,7 @@ namespace UCF\Critical_CSS\API {
 				return new \WP_REST_Response( $retval, 500 );
 			}
 
-			return new \WP_REST_Response( $data->result, 200 );
+			return new \WP_REST_Response( $retval, 200 );
 		}
 
 		/**
@@ -129,10 +129,79 @@ namespace UCF\Critical_CSS\API {
 		 * @param WP_REST_Request The incoming REST request
 		 * @return WP_REST_Response
 		 */
-		public static function update_template( $request ) {
-			$retval = 'Success';
+		public static function update_shared( $request ) {
+			$exp_time = time() + ( 24 * 60 * 60 );
+
+			$retval = array(
+				'result'  => 'success',
+				'message' => ''
+			);
 
 			$body = $request->get_body();
+			$data = json_decode( $body );
+
+			// Make sure the JSON is valid
+			if ( ! $data ) {
+				$retval['result'] = 'error';
+				$retval['message'] = 'There was an error parsing the request body';
+
+				return new \WP_REST_Response( $retval, 400 );
+			}
+
+			// Make sure the CSRF is valid
+			$csrf        = $data->input->args->meta->csrf ?? null;
+			$object_type = $data->input->args->meta->object_type ?? null;
+			$object_id   = $data->input->args->meta->object_id ?? null;
+			$exp_key     = $object_id ? "{$object_id}_expiration" : null;
+
+			if ( $csrf && $object_type && $object_id ) {
+				$token = get_transient( $csrf );
+
+				if ( ! $token ||
+					$token['object_type'] !== $object_type ||
+					$token['object_id'] !== $object_id )
+				{
+					$retval['result'] = 'error';
+					$retval['message'] = 'CSRF Token failure.';
+					return new \WP_REST_Response( $retval, 403 );
+				}
+			}
+
+			// Make sure we were actually sent CSS
+			if ( $data->result === null ) {
+				$retval['result'] = 'error';
+				$retval['message'] = 'There was no critical css in the request';
+
+				return new \WP_REST_Response( $retval, 400 );
+			}
+
+			$success = false;
+
+			if ( ! get_option( $object_id ) ) {
+				$success = add_option( $object_id, $data->result );
+			} else {
+				$success = update_option( $object_id, $data->result );
+			}
+
+			$current_expiration = get_option( $exp_key, null );
+
+			// If we created the transient, set the expiration.
+			if ( $success && ! $current_expiration ) {
+				$success = add_option( $exp_key, $exp_time );
+			} else if ( $success && $current_expiration ) {
+				$success = update_option( $exp_key, $exp_time );
+			}
+
+			// Delete the transient
+			if ( $csrf ) {
+				delete_transient( $csrf );
+			}
+
+			if ( $success === false ) {
+				$retval['result'] = 'error';
+				$retval['message'] = "There was an error updating the $object_type meta";
+				return new \WP_REST_Response( $retval, 500 );
+			}
 
 			return new \WP_REST_Response( $retval, 200 );
 		}

--- a/api/api.php
+++ b/api/api.php
@@ -130,7 +130,7 @@ namespace UCF\Critical_CSS\API {
 		 * @return WP_REST_Response
 		 */
 		public static function update_shared( $request ) {
-			$exp_span = intval( get_option( 'shared_css_expiration', 1440 ) );
+			$exp_span = get_field( 'shared_css_expiration', 'option' );
 			$exp_time = time() + ( $exp_span * 60 ); // Multiply by 60 to convert to seconds.
 
 			$retval = array(

--- a/includes/critical-css.php
+++ b/includes/critical-css.php
@@ -27,9 +27,8 @@ namespace UCF\Critical_CSS\Includes\Critical_CSS {
 					return get_post_meta( $obj->ID, $match['object_name'], true );
 				case 'term_meta':
 					return get_term_meta( $obj->term_id, $match['object_name'], true );
-				case 'transient':
-					// TODO: Add in logic for generating the transient when it expires.
-					return get_transient( $match['object_name'] );
+				case 'option':
+					return get_option( $match['object_name'], null );
 				default:
 					break;
 			}

--- a/includes/deferred-styles.php
+++ b/includes/deferred-styles.php
@@ -12,7 +12,7 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 	 * @return boolean
 	 */
 	function enabled_globally() {
-		return filter_var( get_option( 'options_enable_deferred_styles_global' ), FILTER_VALIDATE_BOOLEAN );
+		return filter_var( get_field( 'enable_deferred_styles_global', 'option' ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
@@ -33,7 +33,7 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 		$critical_css = Critical_CSS\get_critical_css();
 
 		if ( $critical_css ) {
-			$exclude_option = get_option( 'options_deferred_exceptions' );
+			$exclude_option = get_field( 'deferred_exceptions', 'option' );
 			$exclude = $exclude_option ? array_filter( array_map( 'trim', explode( "\n", $exclude_option ) ) ) : array();
 
 			if ( ! in_array( $handle, $exclude ) && $media !== 'print' ) {

--- a/includes/deferred-styles.php
+++ b/includes/deferred-styles.php
@@ -12,7 +12,7 @@ namespace UCF\Critical_CSS\Includes\Deferred_Styles {
 	 * @return boolean
 	 */
 	function enabled_globally() {
-		return filter_var( get_field( 'enable_deferred_styles_global', 'option' ), FILTER_VALIDATE_BOOLEAN );
+		return filter_var( get_option( 'options_enable_deferred_styles_global', false ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Utility command for refreshing critical CSS
+ */
+namespace UCF\Critical_CSS\Includes\CLI {
+	use UCF\Critical_CSS\Admin;
+
+	/**
+	 * WP CLI Command that can refresh Critical CSS
+	 * for shared or individual values.
+	 * @author Jim Barnes
+	 * @since 0.1.0
+	 */
+	class CriticalCSSCommand {
+		/**
+		 * The method that is invoked when
+		 * the command is called.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @param array $args The argument array
+		 * @return void
+		 */
+		public function __invoke( $args ) {
+			Admin\Utilities::update_shared_critical_css();
+		}
+	}
+}

--- a/includes/wp-cli.php
+++ b/includes/wp-cli.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Utility command for refreshing critical CSS
+ * TODO: ALL THE THINGS!!!
  */
 namespace UCF\Critical_CSS\Includes\CLI {
 	use UCF\Critical_CSS\Admin;

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -39,7 +39,7 @@ namespace UCF\Critical_CSS {
 	 */
 	function plugin_init() {
 		add_action( 'acf/init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 10, 0 );
-		add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 20, 1 );
+		add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 10, 1 );
 
 		// Register our dynamic filters and actions
 		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ), 10, 0 );

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -67,6 +67,12 @@ namespace UCF\Critical_CSS {
 		add_filter(
 			'acf/load_field/key=ucfccss_deferred_rules_templates',
 			array( 'UCF\Critical_CSS\Admin\Config', 'get_templates_choices' ), 10, 1 );
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/wp-cli.php';
+
+			\WP_CLI::add_command( 'critical-css', 'UCF\Critical_CSS\Includes\CLI\CriticalCSSCommand' );
+		}
 	}
 
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init', 99, 0 );


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Critical-CSS-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Critical-CSS-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Added the logic for generating and enqueuing shared critical CSS. Currently, the generation can only be triggered by a WP CLI command, which is very incomplete in itself. In the future, both the WP CLI command will be built out for additional utility, and a WP Cron will probably be developed to support triggering the shared CSS generation without needing a cron on the server the site is hosted on.

**Motivation and Context**
The core functions for generation are now in place, and only the triggers for those functions need to be built out.

**How Has This Been Tested?**
The changes have been tested locally with a demonstration of that test posted to the project Slack channel. Currently, it is not possible to test this fully in DEV or QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
