### PR TITLE
Shared css cron

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -242,6 +242,18 @@ link[rel=\'stylesheet\'][href^=\'//cloud.typography.com/\']'
 				'default_value' => 1440 // One day
 			);
 
+			$fields[] = array(
+				'key'           => 'ucfccss_enable_shared_css_cron',
+				'label'         => 'Enable Shared CSS Cron',
+				'name'          => 'enable_shared_css_cron',
+				'type'          => 'true_false',
+				'instructions'  => 'When enabled, an hourly cron will check to see if any shared critical CSS needs to be generated.',
+				'default_value' => 0,
+				'ui'            => 1,
+				'ui_on_text'    => 'Enabled',
+				'ui_off_text'   => 'Disabled'
+			);
+
 			/**
 			 * Define the sub fields for the dimension repeater
 			 */

--- a/admin/utils.php
+++ b/admin/utils.php
@@ -43,6 +43,10 @@ namespace UCF\Critical_CSS\Admin {
 		 * @return void
 		 */
 		public static function update_shared_critical_css() {
+			if ( defined( 'WP_DEBUG' ) and WP_DEBUG ) {
+				error_log( 'Running Shared Critical CSS Cron' );
+			}
+
 			$now = time();
 			$rules = get_field( 'ucfccss_deferred_rules', 'option' );
 

--- a/includes/cron.php
+++ b/includes/cron.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Handles registering and deregistering crons
+ */
+namespace UCF\Critical_CSS\Includes\Cron {
+	/**
+	 * Function that registers the cron based on if the
+	 * cron is enabled in the plugin settings.
+	 * @author Jim Barnes
+	 * @since 0.1.0
+	 * @return void
+	 */
+	function register_cron() {
+		$schedule_cron  = get_option( 'enable_shared_css_cron', 'option' );
+		$next_timestamp = wp_next_scheduled( 'ucfccss_critical_css_cron' );
+
+		if ( $schedule_cron && ! $next_timestamp ) {
+			wp_schedule_event( time(), 'hourly', 'ucfccss_critical_css_cron' );
+		} else if ( ! $schedule_cron && $next_timestamp ) {
+			wp_unschedule_event( $next_timestamp, 'ucfccss_critical_css_cron' );
+		}
+	}
+
+	/**
+	 * Function that deregisters the cron regardless
+	 * of the setting. Meant to be used during the
+	 * deactivation hook.
+	 * @author Jim Barnes
+	 * @since 0.1.0
+	 * @return void
+	 */
+	function disable_cron() {
+		$next_timestamp = wp_next_scheduled( 'ucfccss_critical_css_cron' );
+
+		if ( $next_timestamp ) {
+			wp_unschedule_event( $next_timestamp, 'ucfccss_critical_css_cron' );
+		}
+	}
+}

--- a/includes/cron.php
+++ b/includes/cron.php
@@ -11,6 +11,11 @@ namespace UCF\Critical_CSS\Includes\Cron {
 	 * @return void
 	 */
 	function register_cron() {
+		$screen = get_current_screen();
+
+		// Only do this logic if the save is coming from the settings page
+		if ( $screen->id !== 'settings_page_ucf-critical-css' ) return;
+
 		$schedule_cron  = get_option( 'enable_shared_css_cron', 'option' );
 		$next_timestamp = wp_next_scheduled( 'ucfccss_critical_css_cron' );
 

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -29,6 +29,7 @@ namespace UCF\Critical_CSS {
 
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/critical-css.php';
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/deferred-styles.php';
+	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/cron.php';
 
 	/**
 	 * Main entry function for the plugin.
@@ -73,6 +74,11 @@ namespace UCF\Critical_CSS {
 
 			\WP_CLI::add_command( 'critical-css', 'UCF\Critical_CSS\Includes\CLI\CriticalCSSCommand' );
 		}
+
+		// Register the hook for the cron
+		add_action( 'ucfccss_critical_css_cron', array( 'UCF\Critical_CSS\Admin\Utilities', 'update_shared_critical_css' ) );
+
+		add_action( 'init', 'UCF\Critical_CSS\Includes\Cron\register_cron', 10, 0 );
 	}
 
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init', 99, 0 );

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -41,6 +41,7 @@ namespace UCF\Critical_CSS {
 	function plugin_init() {
 		add_action( 'acf/init', array( 'UCF\Critical_CSS\Admin\Config', 'add_options_page' ), 10, 0 );
 		add_action( 'acf/save_post', array( 'UCF\Critical_CSS\Admin\Config', 'clean_deferred_rules' ), 10, 1 );
+		add_action( 'acf/save_post', 'UCF\Critical_CSS\Includes\Cron\register_cron', 10, 0  );
 
 		// Register our dynamic filters and actions
 		add_action( 'init', array( 'UCF\Critical_CSS\Admin\Actions', 'save_post_actions' ), 10, 0 );
@@ -77,8 +78,6 @@ namespace UCF\Critical_CSS {
 
 		// Register the hook for the cron
 		add_action( 'ucfccss_critical_css_cron', array( 'UCF\Critical_CSS\Admin\Utilities', 'update_shared_critical_css' ) );
-
-		add_action( 'init', 'UCF\Critical_CSS\Includes\Cron\register_cron', 10, 0 );
 	}
 
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\plugin_init', 99, 0 );

--- a/ucf-critical-css.php
+++ b/ucf-critical-css.php
@@ -11,6 +11,7 @@ GitHub Plugin URI: UCF/UCF-Critical-CSS-Plugin
 namespace UCF\Critical_CSS {
 
 	use UCF\Critical_CSS\Includes\Deferred_Styles;
+	use UCF\Critical_CSS\Includes\Cron;
 
 	if ( ! defined( 'WPINC' ) ) {
 		die;
@@ -30,6 +31,19 @@ namespace UCF\Critical_CSS {
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/critical-css.php';
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/deferred-styles.php';
 	include_once UCF_CRITICAL_CSS__PLUGIN_DIR . 'includes/cron.php';
+
+
+	/**
+	 * Runs when the plugin is deactivated.
+	 * @author Jim Barnes
+	 * @since 0.1.0
+	 * @return void
+	 */
+	function on_deactivate() {
+		Cron\disable_cron();
+	}
+
+	register_deactivation_hook( UCF_CRITICAL_CSS__PLUGIN_FILE, __NAMESPACE__ . '\on_deactivate' );
 
 	/**
 	 * Main entry function for the plugin.


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Critical-CSS-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Critical-CSS-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Added the ability to enable an hourly WP Cron that will check if shared critical CSS needs to be generated and fire off the requests if it does.

**Motivation and Context**
We need a way of triggering shared critical CSS generation that doesn't require server side access to schedule cron calls to the WP CLI command. The downside to using this method is every so often, someone's page load is going to be a little show as requests are being made to generate the critical CSS.

**How Has This Been Tested?**
Confirmed the CRON runs on schedule locally. Again, it's not really possible to test this in DEV as we can't get replies back to DEV to confirm the entire process works.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
